### PR TITLE
Fix serializer and transformer

### DIFF
--- a/serializer.py
+++ b/serializer.py
@@ -1,22 +1,24 @@
-
 from grammarinator.runtime import *
+
+
 def simple_space_serializer(root):
-    
-    def _walk(node):
+
+    def _walk(node, add_space=True):
         nonlocal src
 
         if isinstance(node, UnlexerRule):
-            if node.name=='DOT':
-                src = src[:-1]
+            if node.name == "DOT":
+                src = src.rstrip()  # remove whitespace before dots
             if node.src:
                 src += node.src
-            if node.name!='DOT':
-                src += ' '
-        else:
-            for child in node.children:
-                _walk(child)
-        
+            # only add spaces if the node is not a dot
+            if add_space and node.name != "DOT":
+                src += " "
+        if node.name in {"Identifier", "Integral", "Digits", "Numeric"}:
+            add_space = False
+        for child in node.children:
+            _walk(child, add_space)
 
-    src = ''
+    src = ""
     _walk(root)
     return src

--- a/transformer.py
+++ b/transformer.py
@@ -1,19 +1,28 @@
 def anonymizer_transformer(root):
+    def delete_children(node):
+        for child in node.children:
+            child.parent = None
+        node.children = []
+        assert node.children == []
+
     def _walk(node):
         nonlocal idx
 
-        if node.name == 'table_ref':
+        if node.name == "table_ref":
             for child in node.children:
-                if child.name=="Identifier":
-                    child.src="table_name"
-        elif node.name=="columnref":
+                if child.name == "Identifier":
+                    child.src = "table_name"
+                    delete_children(child)
+        elif node.name == "columnref":
             for child in node.children:
-                if child.name=="Identifier":
-                    child.src="column_name"
-        elif node.name=="collabel":
+                if child.name == "Identifier":
+                    child.src = "column_name"
+                    delete_children(child)
+        elif node.name == "collabel":
             for child in node.children:
-                if child.name=="Identifier":
-                    child.src="column_label"
+                if child.name == "Identifier":
+                    child.src = "column_label"
+                    delete_children(child)
 
         for child in node.children:
             _walk(child)
@@ -21,4 +30,3 @@ def anonymizer_transformer(root):
     idx = 0
     _walk(root)
     return root
-


### PR DESCRIPTION
- Delete the children of Identifier nodes (children represent lexer fragments) when replacing the src
- Don't add spaces for certain lexer rules